### PR TITLE
Enforce ISO standard for DateTime inputs.

### DIFF
--- a/gladly_apis/actions/create_task_customerid/request_body.gtpl
+++ b/gladly_apis/actions/create_task_customerid/request_body.gtpl
@@ -6,5 +6,5 @@
         {{end -}}
     },
     "body": "{{.inputs.task}}",
-    "dueAt": "{{.inputs.dueAt}}"
+    "dueAt": "{{date "2006-01-02T15:04:05Z07:00" .inputs.dueAt}}"
 }

--- a/gladly_apis/actions/create_task_email/request_body.gtpl
+++ b/gladly_apis/actions/create_task_email/request_body.gtpl
@@ -6,7 +6,7 @@
         {{end -}}
     },
     "body": "{{.inputs.task}}",
-    "dueAt": "{{.inputs.dueAt}}",
+    "dueAt": "{{date "2006-01-02T15:04:05Z07:00" .inputs.dueAt}}",
     "customer": {
         "emailAddress": "{{.inputs.emailAddress}}"
     }

--- a/gladly_apis/actions/create_task_phone/request_body.gtpl
+++ b/gladly_apis/actions/create_task_phone/request_body.gtpl
@@ -6,7 +6,7 @@
         {{end -}}
     },
     "body": "{{.inputs.task}}",
-    "dueAt": "{{.inputs.dueAt}}",
+    "dueAt": "{{date "2006-01-02T15:04:05Z07:00" .inputs.dueAt}}",
     "customer": {
         "mobilePhone": "{{.inputs.mobilePhone}}"
     }

--- a/gladly_apis/manifest.json
+++ b/gladly_apis/manifest.json
@@ -1,6 +1,6 @@
 {
   "author": "gladly.com",
   "appName": "gladly_apis",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Gladly APIs"
 }


### PR DESCRIPTION
# Summary
- Enforce ISO 8601 standard formatting for Input fields that use a DateTime. (Previously was being formatted to a Go Date.)
- Incremental Patch version

## Testing
- Test with `appcfg run action-graphql`.

Previous failing result:
<img width="814" height="836" alt="image" src="https://github.com/user-attachments/assets/dbf3caec-fecf-4df9-b820-6c91ab7067cf" />

Now passing:
<img width="816" height="724" alt="image" src="https://github.com/user-attachments/assets/70d25dbb-df8c-4637-a94b-c26e3669bf1e" />
