### PR TITLE
Add admin UI form.json for AfterShip app

### DIFF
--- a/aftership/manifest.json
+++ b/aftership/manifest.json
@@ -1,6 +1,6 @@
 {
   "author": "",
   "appName": "",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Aftership for Sidekick can be used to provide the customer with more detailed information about where their package might be."
 }

--- a/aftership/ui/admin/form.json
+++ b/aftership/ui/admin/form.json
@@ -1,0 +1,19 @@
+{
+  "title": "Configure AfterShip",
+  "sections": [
+    {
+      "type": "text",
+      "text": "Enter your AfterShip API credentials below. You can obtain an API key from the AfterShip admin panel under Settings > API Keys."
+    },
+    {
+      "type": "input",
+      "label": "API Key",
+      "attr": "secrets.apiKey",
+      "input": {
+        "type": "text",
+        "placeholder": "Enter your AfterShip API key"
+      },
+      "hint": "Found at https://www.aftership.com/docs/tracking/quickstart/authentication#how-to-get-your-api-key. Ensure the key has permissions to create and read trackings."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `aftership/ui/admin/form.json` for configuring the AfterShip integration from the Gladly admin interface
- The form collects the single required secret: the AfterShip API key (`secrets.apiKey`)
- Field derived from `.integration.secrets.apiKey` reference in `authentication/headers/as-api-key.gtpl` and confirmed via test fixture

## Testing
- [ ] Verify `form.json` is valid JSON
- [ ] Confirm `secrets.apiKey` attr matches the template reference in `authentication/headers/as-api-key.gtpl`
- [ ] Validate form renders correctly in the admin UI

<img width="1509" height="697" alt="Screenshot 2026-04-09 at 11 26 13 AM" src="https://github.com/user-attachments/assets/73780987-c569-4d9a-820e-53392fcf576e" />


## Release Notes
Added admin UI configuration form for the AfterShip integration, enabling administrators to set up the required API key directly from the Gladly admin interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)