### PR TITLE
aftership: remove duplicate GraphQL fields on Tracking type

### DIFF
--- a/aftership/actions/actions_schema.graphql
+++ b/aftership/actions/actions_schema.graphql
@@ -130,10 +130,6 @@ type Tracking {
   subtag_message: String!
   ## Indicates if the shipment is trackable till the final destination.
   last_mile_tracking_supported: Boolean
-  ## Official tracking URL of the courier (if any).
-  courier_tracking_link: String
-  ## Delivery instructions (delivery date or address) can be modified by visiting the link if supported by a carrier.
-  courier_redirect_link: String
   checkpoints: [Checkpoint]
   ## Whether or not the shipment is returned to sender. Value is true when any of its checkpoints has subtag Exception_010 (returning to sender) or Exception_011 (returned to sender). Otherwise value is false.
   return_to_sender: Boolean!

--- a/aftership/manifest.json
+++ b/aftership/manifest.json
@@ -1,6 +1,6 @@
 {
   "author": "",
   "appName": "",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Aftership for Sidekick can be used to provide the customer with more detailed information about where their package might be."
 }


### PR DESCRIPTION
## Summary
- The `Tracking` type in [aftership/actions/actions_schema.graphql](aftership/actions/actions_schema.graphql) declared `courier_tracking_link` and `courier_redirect_link` twice, causing installs to fail with `field [courier_redirect_link] is already defined: OBJECT_DEFINITION -> Tracking`.
- Removed the earlier, less-detailed pair and kept the later pair whose descriptions document the language-parameter fallback behavior (matches the README guidance that prioritizes that field).

## Test plan
- [x] `appcfg validate -r .` passes on the aftership app
- [x] `appcfg build -r .` produces `aftership.com-Aftership-1.1.0.zip`
- [ ] Install the built zip and confirm the 400 schema error is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)