### PR TITLE
recharge: add admin UI form

### DIFF
--- a/recharge/manifest.json
+++ b/recharge/manifest.json
@@ -1,6 +1,6 @@
 {
   "author": "",
   "appName": "",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Manage subscriptions and orders in Gladly"
 }

--- a/recharge/ui/admin/form.json
+++ b/recharge/ui/admin/form.json
@@ -1,0 +1,19 @@
+{
+	"title": "Configure Recharge",
+	"sections": [
+		{
+			"type": "text",
+			"text": "Enter your Recharge API credentials below."
+		},
+		{
+			"type": "input",
+			"label": "Access Token",
+			"attr": "secrets.accessToken",
+			"input": {
+				"type": "text",
+				"placeholder": "Enter your Recharge API access token"
+			},
+			"hint": "Found in the Recharge admin under Tools & Apps > API tokens"
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Adds `ui/admin/form.json` for configuring the Recharge API access token via the Gladly admin interface
- Bumps version from 1.0.0 to 1.1.0


🤖 Generated with [Claude Code](https://claude.com/claude-code)