### PR TITLE
gladly_apis: add admin UI form

### DIFF
--- a/gladly_apis/manifest.json
+++ b/gladly_apis/manifest.json
@@ -1,6 +1,6 @@
 {
   "author": "gladly.com",
   "appName": "gladly_apis",
-  "version": "1.2.1",
+  "version": "1.4.0",
   "description": "Gladly APIs"
 }

--- a/gladly_apis/ui/admin/form.json
+++ b/gladly_apis/ui/admin/form.json
@@ -1,0 +1,39 @@
+{
+	"title": "Configure Gladly APIs",
+	"sections": [
+		{
+			"type": "text",
+			"text": "Enter your Gladly API credentials below. You can generate an API token in Gladly under Settings > API Tokens."
+		},
+		{
+			"type": "input",
+			"label": "Gladly Host",
+			"attr": "configuration.gladlyHost",
+			"input": {
+				"type": "text",
+				"placeholder": "e.g. us-1.gladly.com"
+			},
+			"hint": "Your Gladly instance hostname (e.g. us-1.gladly.com or us-uat.gladly.qa)"
+		},
+		{
+			"type": "input",
+			"label": "Username",
+			"attr": "configuration.username",
+			"input": {
+				"type": "text",
+				"placeholder": "e.g. user@company.com"
+			},
+			"hint": "Email address of a Gladly user with API permissions"
+		},
+		{
+			"type": "input",
+			"label": "API Token",
+			"attr": "secrets.apiToken",
+			"input": {
+				"type": "text",
+				"placeholder": "Enter your Gladly API token"
+			},
+			"hint": "Found in Settings > API Tokens in Gladly"
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Adds `ui/admin/form.json` for configuring Gladly host, username, and API token via the Gladly admin interface
- Bumps version from 1.2.1 to 1.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)