### PR TITLE
loop_returns: add admin UI form

### DIFF
--- a/loop_returns/manifest.json
+++ b/loop_returns/manifest.json
@@ -1,6 +1,6 @@
 {
   "author": "",
   "appName": "loop_returns",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Loop Returns"
 }

--- a/loop_returns/ui/admin/form.json
+++ b/loop_returns/ui/admin/form.json
@@ -1,0 +1,19 @@
+{
+	"title": "Configure Loop Returns",
+	"sections": [
+		{
+			"type": "text",
+			"text": "Enter your Loop Returns API credentials below. You can find your API token in the Loop Returns admin under Settings > API."
+		},
+		{
+			"type": "input",
+			"label": "API Token",
+			"attr": "secrets.apiToken",
+			"input": {
+				"type": "text",
+				"placeholder": "Enter your Loop Returns API token"
+			},
+			"hint": "Found in the Loop Returns admin under Returns Management > Tools & integrations > Developer tools."
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Adds `ui/admin/form.json` for configuring the Loop Returns API token via the Gladly admin interface
- Bumps version from 1.3.0 to 1.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)