### PR TITLE
skio: add admin UI form and bump to v4.1.0

### DIFF
--- a/skio/app/actions/actions_schema.graphql
+++ b/skio/app/actions/actions_schema.graphql
@@ -79,11 +79,6 @@ type Subscription {
 }
 
 # Cancel Subscription Action Types
-input CancelSubscriptionInput {
-  subscriptionId: String!
-  shouldSendNotif: Boolean
-}
-
 type CancelSubscriptionOutput {
   ok: Boolean
   errors: [SkioError!]
@@ -186,7 +181,8 @@ type Mutation {
   Note: This action will report success (`ok: true`) even if the subscription ID does not exist or the subscription was already cancelled.
   """
   cancelSubscription(
-    input: CancelSubscriptionInput!
+    subscriptionId: String!,
+    shouldSendNotif: Boolean
   ): CancelSubscriptionOutput! @action(name: "cancelSubscription")
 
   """

--- a/skio/app/actions/cancelSubscription/_run_/data/success/inputs.json
+++ b/skio/app/actions/cancelSubscription/_run_/data/success/inputs.json
@@ -1,6 +1,4 @@
 {
-  "input": {
-    "subscriptionId": "1e671650-4876-4e80-a0b7-130f355281ac",
-    "shouldSendNotif": true
-  }
+  "subscriptionId": "1e671650-4876-4e80-a0b7-130f355281ac",
+  "shouldSendNotif": true
 }

--- a/skio/app/actions/cancelSubscription/_test_/data/cancel-and-notify/inputs.json
+++ b/skio/app/actions/cancelSubscription/_test_/data/cancel-and-notify/inputs.json
@@ -1,6 +1,4 @@
 {
-  "input": {
-    "subscriptionId": "test-subscription-id",
-    "shouldSendNotif": true
-  }
+  "subscriptionId": "test-subscription-id",
+  "shouldSendNotif": true
 }

--- a/skio/app/actions/cancelSubscription/_test_/data/cancel-only/inputs.json
+++ b/skio/app/actions/cancelSubscription/_test_/data/cancel-only/inputs.json
@@ -1,5 +1,3 @@
 {
-  "input": {
-    "subscriptionId": "test-subscription-id-no-notify"
-  }
+  "subscriptionId": "test-subscription-id-no-notify"
 }

--- a/skio/app/actions/cancelSubscription/_test_/data/invalid-id/inputs.json
+++ b/skio/app/actions/cancelSubscription/_test_/data/invalid-id/inputs.json
@@ -1,6 +1,4 @@
 {
-  "input": {
-    "subscriptionId": "invalid-id",
-    "shouldSendNotif": true
-  }
+  "subscriptionId": "invalid-id",
+  "shouldSendNotif": true
 }

--- a/skio/app/actions/cancelSubscription/request_body.gtpl
+++ b/skio/app/actions/cancelSubscription/request_body.gtpl
@@ -1,4 +1,9 @@
 {
   "query": "mutation cancelSubscription($input: CancelSubscriptionInput!) { cancelSubscription(input: $input) { ok } }",
-  "variables": {{ toJson .inputs}}
+  "variables": {
+    "input": {
+      "subscriptionId": {{ toJson .inputs.subscriptionId }}{{ if .inputs.shouldSendNotif }},
+      "shouldSendNotif": {{ toJson .inputs.shouldSendNotif }}{{ end }}
+    }
+  }
 }

--- a/skio/app/manifest.json
+++ b/skio/app/manifest.json
@@ -1,6 +1,6 @@
 {
-  "appName": "",
-  "author": "",
-  "version": "3.1.0",
+  "appName": "SKIO",
+  "author": "gladly.com",
+  "version": "4.1.0",
   "description": "SKIO integration for managing subscriptions and billing"
 }

--- a/skio/app/ui/admin/form.json
+++ b/skio/app/ui/admin/form.json
@@ -1,0 +1,19 @@
+{
+	"title": "Configure Skio",
+	"sections": [
+		{
+			"type": "text",
+			"text": "Enter your Skio API credentials below. You can find your API token in the Skio admin under Settings > API."
+		},
+		{
+			"type": "input",
+			"label": "API Token",
+			"attr": "secrets.apiToken",
+			"input": {
+				"type": "text",
+				"placeholder": "Enter your Skio API token"
+			},
+			"hint": "Found in the Skio dashboard under API & Integrations > API Keys."
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Drop the CancelSubscriptionInput wrapper so the action takes subscriptionId/shouldSendNotif directly, and update fixtures + request body template to match.
- Add admin UI form at `skio/app/ui/admin/form.json` so the Skio app can be configured from the Apps admin (API token input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)